### PR TITLE
Add authAs()

### DIFF
--- a/src/Collection/User.php
+++ b/src/Collection/User.php
@@ -231,35 +231,35 @@ if (!class_exists('WPTrait\Collection\User')) {
             return wp_signon(['user_login' => $username, 'user_password' => $password, 'remember' => $remember], $secure_cookie);
         }
 
-		/**
-		 * Auth user by id or user_login
-		 * 
-		 * @param string|int|\WP_User $user
-		 * @param bool $remember
-		 * @param string $secure_cookie
-		 * 
-		 * @return void
-		 */
-		public function authAs($user, $remember = false, $secure_cookie = '')
-		{
-			if ($user instanceof \WP_User) {
-				$user = $user->ID;
-			}
+        /**
+         * Auth user by id or user_login
+         * 
+         * @param string|int|\WP_User $user
+         * @param bool $remember
+         * @param string $secure_cookie
+         * 
+         * @return void
+         */
+        public function authAs($user, $remember = false, $secure_cookie = '')
+        {
+            if ($user instanceof \WP_User) {
+                $user = $user->ID;
+            }
 
-			# Retrieve user id
-			if (is_string($user) && !is_numeric($user)) {
-				$user = get_user_by('login', $user);
-				$user = $user->ID;
-			}
+            # Retrieve user id
+            if (is_string($user) && !is_numeric($user)) {
+                $user = get_user_by('login', $user);
+                $user = $user->ID;
+            }
 
-			# Switching to the user
-			wp_clear_auth_cookie();
-			wp_set_auth_cookie($user, $remember, $secure_cookie);
-			$user = wp_set_current_user($user);
+            # Switching to the user
+            wp_clear_auth_cookie();
+            wp_set_auth_cookie($user, $remember, $secure_cookie);
+            $user = wp_set_current_user($user);
 
-			# Let other third-party plugins play
-			do_action('wp_login', $user->user_login, $user);
-		}
+            # Let other third-party plugins play
+            do_action('wp_login', $user->user_login, $user);
+        }
 
         public function logout()
         {

--- a/src/Collection/User.php
+++ b/src/Collection/User.php
@@ -231,6 +231,36 @@ if (!class_exists('WPTrait\Collection\User')) {
             return wp_signon(['user_login' => $username, 'user_password' => $password, 'remember' => $remember], $secure_cookie);
         }
 
+		/**
+		 * Auth user by id or user_login
+		 * 
+		 * @param string|int|\WP_User $user
+		 * @param bool $remember
+		 * @param string $secure_cookie
+		 * 
+		 * @return void
+		 */
+		public function authAs($user, $remember = false, $secure_cookie = '')
+		{
+			if ($user instanceof \WP_User) {
+				$user = $user->ID;
+			}
+
+			# Retrieve user id
+			if (is_string($user) && !is_numeric($user)) {
+				$user = get_user_by('login', $user);
+				$user = $user->ID;
+			}
+
+			# Switching to the user
+			wp_clear_auth_cookie();
+			wp_set_auth_cookie($user, $remember, $secure_cookie);
+			$user = wp_set_current_user($user);
+
+			# Let other third-party plugins play
+			do_action('wp_login', $user->user_login, $user);
+		}
+
         public function logout()
         {
             wp_logout();


### PR DESCRIPTION
Come across a similar issue but I have my own way to deal with it, we can authenticate a user by user id, username/user login, and WP_User object then let other third parties to play.