### PR TITLE
Update Model.php

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -209,7 +209,7 @@ if (!class_exists('WPTrait\Model')) {
                 $hook = substr($hooks, 0, -1);
                 if (is_array($this->{$hooks})) {
                     foreach ((array)$this->{$hooks} as $name => $args) {
-                        if (is_array($args) and !is_numeric($args[1])) {
+                        if (is_array($args) && (!isset($args[1]) || !is_numeric($args[1]))) {
                             foreach ($args as $method) {
                                 $this->runVariableHooks($hook, $name, $method);
                             }


### PR DESCRIPTION
Check to see if arg[1] exists to avoid warning of index not existing

I had a set of actions that were defined as follows:
```
    public $actions = [
        'init' => 'actions_init',
        'woocommerce_loaded' => 'actions_woocommerce_loaded',
        'woocommerce_archive_description' => 'actions_woocommerce_archive_description',
        'pre_get_posts' => ['actions_pre_get_posts'],
        'woocommerce_process_shop_coupon_meta' => ['actions_woocommerce_process_shop_coupon_meta', PHP_INT_MAX, 2],
    ];
```
The pre_get_posts action was triggering a warning for $arg[1] not being present.  I likely had previously defined the priority but later removed it leaving just the action in an array, but without a priority