### PR TITLE
Post query, list, and Meta fixes

### DIFF
--- a/src/Collection/Route.php
+++ b/src/Collection/Route.php
@@ -31,7 +31,7 @@ if (!class_exists('WPTrait\Collection\Route')) {
             }
 
             # Sanitize method name
-            $args['methods'] = strtoupper($args['methods']);
+            $args['methods'] = array_map('strtoupper', (array) $args['methods']);
 
             # Sanitize Callback Method
             if (is_string($args['callback'])) {
@@ -76,5 +76,4 @@ if (!class_exists('WPTrait\Collection\Route')) {
             return (object)$rest;
         }
     }
-
 }

--- a/src/Data/Meta.php
+++ b/src/Data/Meta.php
@@ -47,14 +47,14 @@ if (!class_exists('WPTrait\Data\Meta')) {
             }, get_metadata($this->type, $this->id, '', false));
         }
 
-        public function only(): array
+        public function only($keys = []): array
         {
-            return Arr::only($this->all(), func_get_args());
+            return Arr::only($this->all(), $keys);
         }
 
-        public function except(): array
+        public function except($keys = []): array
         {
-            return Arr::except($this->all(), func_get_args());
+            return Arr::except($this->all(), $keys);
         }
 
         public function exists($key): bool
@@ -109,6 +109,5 @@ if (!class_exists('WPTrait\Data\Meta')) {
             }
             return $this;
         }
-
     }
 }

--- a/src/Data/Post.php
+++ b/src/Data/Post.php
@@ -608,7 +608,7 @@ if (!class_exists('WPTrait\Data\Post')) {
 
         public function list($args = []): array
         {
-            $query = $this->query($args);
+            $query = self::query($args);
             return ($query->have_posts() ? $query->posts : []);
         }
 

--- a/src/Data/Post.php
+++ b/src/Data/Post.php
@@ -598,7 +598,7 @@ if (!class_exists('WPTrait\Data\Post')) {
                 'order' => 'DESC'
             ];
 
-            $args = wp_parse_args($default, $arg);
+            $args = wp_parse_args($arg, $default);
 
             # Return { $query->posts }
             # Get SQL { $query->request }


### PR DESCRIPTION
implement query from old post class, add list function for backward compat, fix meta only and except warning.

After pulling the newest master version, I needed to implement a couple things that I used in some plugin implementations that use wp-trait.

I took the old post query implementation and adjusted it to allow for static implementation.  I removed the post_type from the default params, and switched the order for wp_parse_args to apply args on top of defaults.  Added list function that returns $query->posts if not empty.

The meta class I changed because when feeding in:
$meta = $this->post->find($block->ID)->meta()->only(['hook', 'priority']);

the only method was using func_get_args() which nested the array:
0 => [
  0 => 'hook',
  1 => 'priority'
]
This caused the array flip to complain as it was trying to flip 0 => array

Not sure about the static? Any suggestions there?

